### PR TITLE
feat: Update PWA manifest for enhanced experience

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,32 +2,10 @@
   "name": "Notention",
   "short_name": "Notention",
   "description": "A streamlined, powerful notebook app integrating LM capabilities.",
-  "start_url": "/",
+  "scope": "/untention2/",
+  "start_url": "/untention2/",
+  "id": "/untention2/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#0d47a1",
-  "icons": [
-    {
-      "src": "/icons/icon-192x192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
-      "type": "image/png",
-      "sizes": "192x192",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/icons/icon-512x512.png",
-      "type": "image/png",
-      "sizes": "512x512",
-      "purpose": "maskable"
-    }
-  ]
+  "theme_color": "#0d47a1"
 }


### PR DESCRIPTION
- Updated public/manifest.json to include scope, id, and start_url fields, all set to /untention2/ to align with GitHub Pages base path.
- Removed icons array from public/manifest.json to centralize icon definition in vite.config.ts, allowing vite-plugin-pwa to manage pathing.
- Noted that actual icon image files need to be added to public/icons/ for full PWA functionality.